### PR TITLE
Recipe instances launch/end uses new recipeInstances service.

### DIFF
--- a/src/brewhouse/brewhouse-terminator.directive.js
+++ b/src/brewhouse/brewhouse-terminator.directive.js
@@ -3,9 +3,9 @@
     .module('app.brewhouse')
     .directive('brewhouseTerminator', brewhouseTerminator);
 
-  brewhouseTerminator.$inject = ['$http', '$uibModal'];
+  brewhouseTerminator.$inject = ['$http', '$uibModal', 'recipeInstances'];
 
-  function brewhouseTerminator($http, $uibModal) {
+  function brewhouseTerminator($http, $uibModal, recipeInstances) {
     return {
       restrict: 'E',
       transclude: true,
@@ -29,13 +29,7 @@
         }
 
         function endRecipeInstanceOnServer() {
-          $http({
-            method: 'POST',
-            url: '/brewery/brewhouse/end',
-            data: {
-              recipe_instance: $scope.recipeInstance,
-            },
-          }).then(unsetrecipeInstance);
+          recipeInstances.end($scope.recipeInstance).then(unsetrecipeInstance);
         }
 
         function unsetrecipeInstance() {

--- a/src/brewhouse/brewhouse-terminator.directive.spec.js
+++ b/src/brewhouse/brewhouse-terminator.directive.spec.js
@@ -31,7 +31,7 @@ describe('app.brewhouse', function () {
       scope.$digest();
       isolatedScope = element.isolateScope();
 
-      endSessionPost = $httpBackend.when('POST', '/brewery/brewhouse/end')
+      endSessionPost = $httpBackend.when('POST', 'brewery/api/brewhouse/end/')
           .respond();
     });
 
@@ -45,7 +45,7 @@ describe('app.brewhouse', function () {
         const modalInstance = isolatedScope.endSession();
         scope.recipeInstance = 12;
         scope.$digest();
-        $httpBackend.expectPOST('/brewery/brewhouse/end',
+        $httpBackend.expectPOST('brewery/api/brewhouse/end/',
             {recipe_instance: 12})
         modalInstance.close();
         $rootScope.$apply();

--- a/src/recipes/recipe-card.directive.js
+++ b/src/recipes/recipe-card.directive.js
@@ -3,9 +3,9 @@
     .module('app.recipes')
     .directive('recipeCard', recipeCard);
 
-  recipeCard.$inject = ['$uibModal', '$http', '$location'];
+  recipeCard.$inject = ['$uibModal', '$http', '$location', 'recipeInstances'];
 
-  function recipeCard($uibModal, $http, $location) {
+  function recipeCard($uibModal, $http, $location, recipeInstances) {
     return {
       restrict: 'E',
       transclude: true,
@@ -73,14 +73,8 @@
          * @param {object} launchRecipeResult Result from the launchRecipe modal.
          */
         function performLaunch(recipe, launchRecipeResult) {
-          $http({
-            method: 'POST',
-            url: 'brewery/brewhouse/launch',
-            data: {
-              recipe: recipe.id,
-              brewhouse: launchRecipeResult.brewhouse.id,
-            },
-          }).then(navigateToBrewhouse);
+          recipeInstances.launch(recipe.id, launchRecipeResult.brewhouse.id)
+            .then(navigateToBrewhouse);
 
           function navigateToBrewhouse() {
             $location

--- a/src/recipes/recipe-card.directive.spec.js
+++ b/src/recipes/recipe-card.directive.spec.js
@@ -66,7 +66,8 @@ describe('app.recipes', function () {
       var launchRecipePost;
 
       beforeEach(function () {
-        launchRecipePost = $httpBackend.when('POST', 'brewery/brewhouse/launch')
+        launchRecipePost = $httpBackend.when(
+            'POST', 'brewery/api/brewhouse/launch/')
           .respond();
 
         $httpBackend.expectGET('brewery/api/brewhouse');
@@ -79,14 +80,14 @@ describe('app.recipes', function () {
       });
 
       it('should call performLaunch', function () {
-        $httpBackend.expectPOST('brewery/brewhouse/launch');
+        $httpBackend.expectPOST('brewery/api/brewhouse/launch/');
         modalInstance.close({ brewhouse: { id: 0 } });
         $rootScope.$apply();
         $httpBackend.flush();
       });
 
       it('calling performLaunch should change the url', function () {
-        $httpBackend.expectPOST('brewery/brewhouse/launch');
+        $httpBackend.expectPOST('brewery/api/brewhouse/launch/');
         modalInstance.close({ brewhouse: { id: 0 } });
         $rootScope.$apply();
         $httpBackend.flush();

--- a/src/recipes/recipe-instances.service.js
+++ b/src/recipes/recipe-instances.service.js
@@ -1,0 +1,57 @@
+(function loadRecipeInstancesService() {
+  angular
+    .module('app.common')
+    .service('recipeInstances', recipeInstances);
+
+  recipeInstances.$inject = ['$http'];
+
+  function recipeInstances($http) {
+    const self = this;
+
+    self.launch = launch;
+    self.end = end;
+
+    /**
+     * Launches a recipe instance of a recipe on a brewhouse. Sends a request to
+     * start the service and returns a promise for the request.
+     *
+     * @param{Number} recipeId The primary key for the recipe to launch.
+     * @param{Number} brewhouesId The primary key for the brewhouse to launch
+     *   the recipe on.
+     *
+     * @returns The promise for the http request to the server to launch the
+     *   recipe instance. Response should include the primary key for the
+     *   new recipe instance keyed on "recipe_instance".
+     */
+    function launch(recipeId, brewhouseId) {
+      return $http({
+        method: 'POST',
+        url: 'brewery/api/brewhouse/launch/',
+        data: {
+          recipe: recipeId,
+          brewhouse: brewhouseId,
+        },
+      });
+    }
+
+    /**
+     * Ends a currently active recipe instance. Sends a request to the server to
+     * terminate the recipe instance.
+     *
+     * @param{Number} recipeInstanceId The primary key for the active recipe
+     *   instance to terminate.
+     *
+     * @returns The promise for the http request to the server to end the
+     *   recipe instance.
+     */
+    function end(recipeInstanceId) {
+      return $http({
+        method: 'POST',
+        url: 'brewery/api/brewhouse/end/',
+        data: {
+          recipe_instance: recipeInstanceId,
+        },
+      });
+    }
+  }
+}());

--- a/src/recipes/recipe-instances.service.spec.js
+++ b/src/recipes/recipe-instances.service.spec.js
@@ -1,0 +1,60 @@
+/* eslint-disable */
+describe('app.common recipe-instances.service', function () {
+  beforeEach(module('app.common'));
+
+  var $httpBackend;
+
+  beforeEach(inject(function ($injector) {
+    $httpBackend = $injector.get('$httpBackend');
+  }));
+
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe('recipeInstances service', function () {
+    var recipeInstances;
+
+    beforeEach(inject(function (_recipeInstances_) {
+      recipeInstances = _recipeInstances_;
+    }));
+
+    it('should be defined', function() {
+      expect(recipeInstances).toBeDefined();
+    });
+
+    describe('launch', function () {
+      it('returns a promise', function () {
+        const recipeInstanceId = 12;
+        $httpBackend.when('POST', 'brewery/api/brewhouse/launch/')
+          .respond({id: recipeInstanceId});
+        var foo = 0;
+        const recipeId = 10;
+        const brewhouseId = 11;
+        $httpBackend.expectPOST('brewery/api/brewhouse/launch/');
+        recipeInstances.launch(recipeId, brewhouseId).then(function(response){
+          foo = response.data.id;
+        });
+        $httpBackend.flush();
+        expect(foo).toBe(recipeInstanceId);
+      });
+    });
+
+    describe('end', function () {
+      it('returns a promise', function () {
+        $httpBackend.when('POST', 'brewery/api/brewhouse/end/')
+          .respond();
+        var called = false;
+        const recipeInstanceId = 12;
+        $httpBackend.expectPOST('brewery/api/brewhouse/end/');
+        recipeInstances.end(recipeInstanceId).then(function(response){
+          called = true;
+        });
+        $httpBackend.flush();
+        expect(called).toBeTruthy();
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
This centralizes logic for interacting with server API by providing a client API.